### PR TITLE
Add_mimemagic ~ BundleUpdate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,3 +82,5 @@ gem 'jquery-rails'
 gem 'rails-i18n'
 
 gem 'fog-aws'
+
+gem "mimemagic", "~> 0.3.10"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,7 +198,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
@@ -412,6 +414,7 @@ DEPENDENCIES
   jp_prefecture
   jquery-rails
   listen (>= 3.0.5, < 3.2)
+  mimemagic (~> 0.3.10)
   mini_magick
   mysql2 (>= 0.4.4)
   payjp


### PR DESCRIPTION
# What
mimemagic を Gemfile に追加。
bundle update mimemagic を実行。

# Why
mimemagic ライセンス問題で bundle install ができない為。
2021年3月下旬頃、mimemagic gem がライセンス関連の問題で rubygems.org から取り下げられた。
現在は mimemagic 0.3.7 以降に関してはライセンス関連の問題は解消されている。