### PR TITLE
Add_Capifile_load

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -13,3 +13,5 @@ require 'capistrano3/unicorn'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }
+
+load 'deploy/assets'

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -6,7 +6,7 @@ Rails.application.config.assets.version = '1.0'
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path
 # Add Yarn node_modules folder to the asset load path.
-Rails.application.config.assets.paths << Rails.root.join('node_modules')
+# Rails.application.config.assets.paths << Rails.root.join('node_modules')
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets


### PR DESCRIPTION
# What
Capfile に load の項目を追記。

# Why
デプロイ後の画像データ未反映を直す為。
load 項目の追記により本番環境での config.assets.prefix の読み込みディレクトリが "/assets" から "shared/assets" に変更される。